### PR TITLE
Added 2 new Arguments: '--skip-printout' & '--collection'

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ e.g. `plex_playlist_generator.py --account --username MyUserName --password Sh1t
 
 ### Server
 Uses The Server URL and Authentication Token  
-e.g. `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --allshows`
+e.g. `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allshows`
 
 ### Authentication Token
 To get your Auth token, browse to an episode in the web UI. Click on the `...` video and select `Get Info`.  In the 
@@ -94,27 +94,27 @@ The default behavior of the script for TV Shows is that if its a show a user has
 Generate 10 random unwatched TV Show episodes:  
     `plex_playlist_generator.py --server --baseurl "https://your.domain.com:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allshows --homeusers John`
 
-Generate 10 random unwatched epsidodes for the 3 provided homeusers (Johnny,Smith,Curry): 
-    `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allshows --homeusers "John,Smith,Curry" --excludeilibrary "TV Shows,Movies"`
+Generate 10 random unwatched epsidodes for the 3 provided homeusers (Johnny,Smith,Curry), excluding shows from the library section "Animated TV Shows": 
+    `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allshows --homeusers "John,Smith,Curry" --exclude-library "Animated TV Shows"`
 
 Generate 10 random unwatched movies for the admin user:
     `plex_playlist_generator.py --server --baseurl "https://your.domain.com:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allmovies --adminuser`
 
-Generate 5 random unwatched Movies for the 3 provided homeusers (Johnny,Smith,Curry): 
+Generate 5 random unwatched Movies for the 3 provided homeusers (Johnny,Smith,Curry), and the admin user: 
   `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allmovies --adminuser --homeusers "John,Smith,Curry" --number 5`
 
 Generate 3 random unwatched epsidodes for all home users on the plex server:
     `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allmovies --adminuser --homeusers all --number 3`
 
-Ignore The facty that not all episodes are available for a show in your library [highly recommend using to reduce processing time]
-    `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allmovies --adminuser --homeusers "all" --ignore-skipped`
+Ignore the fact that not all episodes are available for a show in your library (set by default to reduce processing time)
+    `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allshows --adminuser --homeusers "all" --ignore-skipped`
 
 Generate a mix 8 random shows and movies:
-    `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allmovies --homeusers --allshows --allmovies --number 8`
+    `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allmovies --allshows --homeusers John --allmovies --number 8`
 
-Generate a playlist with the name "Test1" for all home users:
-`plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allmovies --adminuser --homeusers "all" --name "Test1"`
+Generate a playlist from the library section "TV Shows" with the name "Test1" for **all** home users:
+`plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --select-library "TV Shows" --adminuser --homeusers "all" --name "Test1"`
 
-Delete a playlist with the name "Test1" for all home users:
-    `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --adminuser --homeusers "all" --purge`
+Delete a playlist with the name "Test1" for **all** home users:
+    `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --adminuser --homeusers "all" --name "Test1" --purge`
 

--- a/README.md
+++ b/README.md
@@ -92,25 +92,25 @@ The default behavior of the script for TV Shows is that if its a show a user has
 ### Examples:
 
 Generate 10 random unwatched TV Show episodes:  
-    `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --allshows --homeusers John`
+    `plex_playlist_generator.py --server --baseurl "https://your.domain.com:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allshows --homeusers John`
 
 Generate 10 random unwatched epsidodes for the 3 provided homeusers (Johnny,Smith,Curry): 
     `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allshows --homeusers "John,Smith,Curry" --excludeilibrary "TV Shows,Movies"`
 
 Generate 10 random unwatched movies for the admin user:
-    `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --allmovies --admin`
+    `plex_playlist_generator.py --server --baseurl "https://your.domain.com:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allmovies --admin`
 
 Generate 5 random unwatched Movies for the 3 provided homeusers (Johnny,Smith,Curry): 
   `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allmovies --admin --homeusers "John,Smith,Curry" --number 5`
 
 Generate 3 random unwatched epsidodes for all home users on the plex server:
-    `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --allmovies --admin --homeusers all --number 3`
+    `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allmovies --admin --homeusers all --number 3`
 
 Ignore The facty that not all episodes are available for a show in your library [highly recommend using to reduce processing time]
     `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allmovies --admin --homeusers "all" --ignore-skipped`
 
 Generate a mix 8 random shows and movies:
-    `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --allmovies --homeusers --allshows --allmovies --number 8`
+    `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allmovies --homeusers --allshows --allmovies --number 8`
 
 Generate a playlist with the name "Test1" for all home users:
 `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allmovies --admin --homeusers "all" --name "Test1"`

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Uses either the Account Method or Server Method to generate playlist of movies a
 >
 >Note: any of the below commands can be run by either connection method (Server/Account).
 >
-The default behavior of the script for TV Shows is that if its a show a user has began watchhing the script will begin with the episode you are currently on.
+The default behavior of the script for TV Shows is that if its a show a user has began watching the script will begin with the episode you are currently on.
 
 
 ### Examples:

--- a/README.md
+++ b/README.md
@@ -98,23 +98,23 @@ Generate 10 random unwatched epsidodes for the 3 provided homeusers (Johnny,Smit
     `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allshows --homeusers "John,Smith,Curry" --excludeilibrary "TV Shows,Movies"`
 
 Generate 10 random unwatched movies for the admin user:
-    `plex_playlist_generator.py --server --baseurl "https://your.domain.com:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allmovies --admin`
+    `plex_playlist_generator.py --server --baseurl "https://your.domain.com:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allmovies --adminuser`
 
 Generate 5 random unwatched Movies for the 3 provided homeusers (Johnny,Smith,Curry): 
-  `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allmovies --admin --homeusers "John,Smith,Curry" --number 5`
+  `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allmovies --adminuser --homeusers "John,Smith,Curry" --number 5`
 
 Generate 3 random unwatched epsidodes for all home users on the plex server:
-    `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allmovies --admin --homeusers all --number 3`
+    `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allmovies --adminuser --homeusers all --number 3`
 
 Ignore The facty that not all episodes are available for a show in your library [highly recommend using to reduce processing time]
-    `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allmovies --admin --homeusers "all" --ignore-skipped`
+    `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allmovies --adminuser --homeusers "all" --ignore-skipped`
 
 Generate a mix 8 random shows and movies:
     `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allmovies --homeusers --allshows --allmovies --number 8`
 
 Generate a playlist with the name "Test1" for all home users:
-`plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allmovies --admin --homeusers "all" --name "Test1"`
+`plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allmovies --adminuser --homeusers "all" --name "Test1"`
 
 Delete a playlist with the name "Test1" for all home users:
-    `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allmovies --admin --homeusers "all" --purge`
+    `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --adminuser --homeusers "all" --purge`
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Library Selection Behavior:
   --allshows             Grab All Shows in all Library sections From Plex
   --allmovies            Grab All Movies in all Library sections From Plex
   --select-library, -l   SELECT_LIBRARY   Choose between library sections of both TV Shows or Movies to build a playlist from (comma seperated within quotes if multiple users)
-  --exclude-library -e   EXCLUDE_LIBRARY  Comma seperated list (if selecting multiple users) of sections to exclude (I.E. "Test Videos,Workout,Home Videos" ) there should be no space between the comma and the first character of the next value
+  --exclude-library, -e  EXCLUDE_LIBRARY  Comma seperated list (if selecting multiple users) of sections to exclude (I.E. "Test Videos,Workout,Home Videos" ) there should be no space between the comma and the first character of the next value
   --purge                Remove a playlist from plex for the provided user(s)
 
 User Profile Selection:

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ series in order
 
 ##Usage
 ```
-usage: plex_playlist_generator.py [-h] [--name NAME] [--number NUMBER] [--debug]
+usage: plex_playlist_generator.py [-h] [--name NAME] [--number NUMBER] [--debug] [--skip-printout]
                                   [--server] [--baseurl BASEURL] [--token TOKEN] [--account]
                                   [--username USERNAME] [--password PASSWORD]
                                   [--resource RESOURCE] [--tvdb-api-key TVDB_API_KEY]
                                   [--ignore-skipped] [--randomize] [--include-watched]
                                   [--allshows] [--allmovies] [--select-library SELECT_LIBRARY]
-                                  [--exclude-library EXCLUDE_LIBRARY] [--purge] [--adminuser]
-                                  [--homeusers HOMEUSERS]
+                                  [--exclude-library EXCLUDE_LIBRARY] [--purge]
+                                  [--collection COLLECTION] [--adminuser] [--homeusers HOMEUSERS]
 
 Create playlist of unwatched episodes from random shows but in correct episode
 order.
@@ -23,6 +23,7 @@ optional arguments:
   --number NUMBER, -n NUMBER
                         Number of episodes or Movies to add to play list
   --debug, -d           Debug Logging
+  --skip-printout       Skip printing the output to the console (will decrease runtime).
 
 Server Connection Method:
   --server              Server connection Method
@@ -53,6 +54,10 @@ Library Selection Behavior:
   --select-library, -l   SELECT_LIBRARY   Choose between library sections of both TV Shows or Movies to build a playlist from (comma seperated within quotes if multiple users)
   --exclude-library, -e  EXCLUDE_LIBRARY  Comma seperated list (if selecting multiple users) of sections to exclude (I.E. "Test Videos,Workout,Home Videos" ) there should be no space between the comma and the first character of the next value
   --purge                Remove a playlist from plex for the provided user(s)
+
+Collections Tag Filter:
+  --collection COLLECTION, -c COLLECTION
+                        Retrieve's items that are part of a Collection matching the name provided to '--collection', and will be applied to each library that the user selected.
 
 User Profile Selection:
   --adminuser, -a        Generate playlist for the Plex Admin user profile name that was used to login.
@@ -109,8 +114,11 @@ Generate 3 random unwatched epsidodes for all home users on the plex server:
 Ignore the fact that not all episodes are available for a show in your library (set by default to reduce processing time)
     `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allshows --adminuser --homeusers "all" --ignore-skipped`
 
-Generate a mix 8 random shows and movies:
-    `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allmovies --allshows --homeusers John --allmovies --number 8`
+Generate a mix of 8 random shows and movies:
+    `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allmovies --allshows --homeusers John --number 8`
+
+Generate a mix of 8 random shows and movies that are a part of a collection named "**Christmas**" for the associated Libraries provided:
+    `plex_playlist_generator.py --server --baseurl "http://172.16.1.100:32400" --token "fR5GrDxfLunKynNub5" --resource MyServer --allmovies --allshows --homeusers John --number 8 --collection "Christmas"`
 
 Generate a playlist from the library section "TV Shows" with the name "Test1" for **all** home users:
 `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --select-library "TV Shows" --adminuser --homeusers "all" --name "Test1"`
@@ -118,3 +126,5 @@ Generate a playlist from the library section "TV Shows" with the name "Test1" fo
 Delete a playlist with the name "Test1" for **all** home users:
     `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --adminuser --homeusers "all" --name "Test1" --purge`
 
+Skip the printout of the playlist to the screen:
+    `plex_playlist_generator.py --account --username MyUserName --password Sh1tPass --resource MyServer --allshows --adminuser --homeusers "all" --skip-printout`

--- a/plex_playlist_generator.py
+++ b/plex_playlist_generator.py
@@ -1278,7 +1278,7 @@ def generate_all_users_playlist_via_account_method(plexConnection, accountInfo, 
                 try:
                     #if plex_user in homeUsers: 
                     logger.debug('\nChecking if the user is a Plex Home guest...\n')
-                    logger.debug(f'\nHome User [matched]: {str(homeUser)}\n')    
+                    logger.debug(f'\nHome User [matched]: {homeUser}\n')    
                     logger.debug(f'Switching to user: [{homeUser}] ...\n')
                     
                     print(f'-----------[BEGIN]-------------- {homeUser} -------------[BEGIN]--------------')

--- a/plex_playlist_generator.py
+++ b/plex_playlist_generator.py
@@ -238,7 +238,7 @@ def get_random_episodes_or_movies(plex, all_provided_sections, requested_playlis
                     
                 except IndexError as e:
                     #If the Index is out of range (this can occur if the seasons after the special seasons have all been watched).
-                    print(f'\nIndex that Procceeds \"{show.title} - {season_episode} - {episode_title}\" is out of Range :: {e}\n')
+                    print(f'\nIndex that comes after \"{show.title} - {season_episode} - {episode_title}\" is out of Range :: {e}\n')
                     break
 
 
@@ -451,7 +451,7 @@ def delete_playlist(plex, account, playlistName):
 #Arguments are the plex connection, the name of the user we are acting as for playlist generation, the formatted plex library sections, and the Excluded List of Library Sections
 def build_playlist(plex, userName, plex_refined_library_sections, selectionsToExclude_List):  
     #The plex_refined_library_sections is the library sections after removing the excluded list
-    #The librarySelection is the selected library that was passed in whether from using --allshows, --allmovies, or --selectlibrary
+    #The librarySelection is the selected library that was passed in whether from using --allshows, --allmovies, or --select-library
 
     #number of Media items added to the library.
     libraryCount = 0 
@@ -466,7 +466,7 @@ def build_playlist(plex, userName, plex_refined_library_sections, selectionsToEx
         exit(1)
 
 
-    #If the user selected libraries with the --selectlibrary argument
+    #If the user selected libraries with the --select-library argument
     if(args.select_library != None):
         randomSelectedLibrary = random.choice(plex_refined_library_sections)
     else:
@@ -828,7 +828,7 @@ def create_playlist(plex, account):
             if not foundMatchInExclude and not foundMatchInUSerSelection:
                 logger.debug(f'Adding library \"{library}\" to List of selectionsToExcludeBasedOnWhatUserSelected_List')
 
-                #Add the library to the Full list of what was excluded library sections for everything that is not in --selectlibrary argument passed in by the user
+                #Add the library to the Full list of what was excluded library sections for everything that is not in --select-library argument passed in by the user
                 selectionsToExcludeBasedOnWhatUserSelected_List.append(library)
                 
             # #if library is one of the selected sections requested by the user, add it.
@@ -840,7 +840,7 @@ def create_playlist(plex, account):
             else:
                 logger.debug(f'Adding library \"{library}\" to List of selectionsToExcludeBasedOnWhatUserSelected_List')
                 
-                #Add the library to the Full list of what was excluded library sections for everything that is not in --selectlibrary argument passed in by the user
+                #Add the library to the Full list of what was excluded library sections for everything that is not in --select-library argument passed in by the user
                 selectionsToExcludeBasedOnWhatUserSelected_List.append(library)
 
         else:
@@ -1360,10 +1360,10 @@ def main():
 
     #If the user enters the selectLibrary argument
     if(args.select_library != None) and (args.allshows == True):
-        print(f'\nERROR - The \"selectLibrary\" argument cannot be used in conjunction with the \"allShows\" argument.\n')
+        print(f'\nERROR - The \"--select-library\" argument cannot be used in conjunction with the \"--allShows\" argument.\n')
         exit(1)
     elif(args.select_library != None) and (args.allmovies == True):
-        print(f'\nERROR - The \"selectLibrary\" argument cannot be used in conjunction with the \"allmovies\" argument.\n')
+        print(f'\nERROR - The \"--select-library\" argument cannot be used in conjunction with the \"--allmovies\" argument.\n')
         exit(1)
     
     #If the user does not provide a user to apply the playlist creation/deletion to, print an Error, and exit.
@@ -1371,11 +1371,17 @@ def main():
         print(f'\nERROR - The script requires the use of at least one User.\n\nAvailable options:\n [1] - adminuser (--adminuser) \n [2] - homeusers (--homeusers "Username1,Username2,...")\n')
         exit(1)
 
-    #If the user does not pass in either of the following arguments: --selectlibrary, --allshows, or --allmovies, or --purge
+    #If the user does not pass in either of the following arguments: --select-library, --allshows, --allmovies, or --purge
     if(args.select_library == None) and (args.allshows == False) and (args.allmovies == False) and (args.purge == False):
         print('\nERROR - One of the required arguments must be selected.')
         print(f'        Rerun your command with one of the following required Arguments:')
-        print(f'        --selectlibrary\n        --allshows\n        --allmovies\n        --purge\n')
+        print(f'        --select-library\n        --allshows\n        --allmovies\n        --purge\n')
+        time.sleep(3)
+        exit(1)
+    #If purge argument is used, then it should not be used at the same time as the following arguments: --select-library, --allshows, or --allmovies
+    elif(args.select_library != None) or (args.allshows != False) or (args.allmovies != False) and (args.purge != False):
+        print('\nERROR - The \"--purge\" argument cannot be used in conjuction with the following arguments:')
+        print(f'        --select-library\n        --allshows\n        --allmovies\n')
         time.sleep(3)
         exit(1)
 

--- a/plex_playlist_generator.py
+++ b/plex_playlist_generator.py
@@ -185,7 +185,6 @@ def get_random_episodes_or_movies(plex, all_provided_sections, requested_playlis
                 logger.debug(f'GET_EPISODES: Show Blacklisted: {show.title}')
                 continue
             if args.include_watched is True:
-                #show_episodes[show.title] = show.episodes()
                 #Grab Watched Episodes but ignore Season 0 (Specials)
                 show_episodes[show.title] = show.episodes(parentIndex__gt=0)
             else:
@@ -561,7 +560,6 @@ def build_playlist(plex, userName, plex_refined_library_sections, selectionsToEx
                     print(f'\nExcluded Library Sections: {selectionsToExclude_List}')
         
                 logger.debug(f'\n\nepisode [label] = {(episode_movie.TYPE)}\n\n')
-                #print(f'\nplexMovieType = {plexMovieType}\n')
                 season_episode = episode_movie.seasonEpisode      
                 print(f'\nAdded to Playlist [{args.name}]: \"{episode_movie.grandparentTitle} - {episode_movie.parentTitle} - '
                       f'Ep.0{episode_movie.index} - {episode_movie.title}\"')
@@ -572,9 +570,7 @@ def build_playlist(plex, userName, plex_refined_library_sections, selectionsToEx
            
     #For Movies Only      
     elif (args.allshows == False) and (args.allmovies == True):
-        #movies = get_random_movies(all_Shows_or_Movies_Library_Selection, n=1)
         episode_or_movie = get_random_episodes_or_movies(plex, plex_refined_library_sections, args.number)
-        
         
         try:
             #If a playlist with the same name already exist, delete it
@@ -649,7 +645,6 @@ def create_playlist(plex, account):
         allSections_List.append(section.title)
     
     #for the section in allSections (converted to String):
-    #allSections_String = str(getAllSections)
     allShowSections_String = str()
     allMovieSections_String = str()
     
@@ -674,7 +669,6 @@ def create_playlist(plex, account):
         
     #If the user did NOT Select The library selection, default plex_all_tv_and_movie_library_sections_minus_exluded to a Default of the full list of sections in order to remove from the list anything that is in the excluded list
     else:
-        #plex_all_tv_and_movie_library_sections_minus_exluded = allSections_List
         plex_all_tv_and_movie_library_sections_minus_exluded = list()
         
         #Used to build a list of everything that was excluded 

--- a/plex_playlist_generator.py
+++ b/plex_playlist_generator.py
@@ -1379,7 +1379,7 @@ def main():
         time.sleep(3)
         exit(1)
     #If purge argument is used, then it should not be used at the same time as the following arguments: --select-library, --allshows, or --allmovies
-    elif(args.select_library != None) or (args.allshows != False) or (args.allmovies != False) and (args.purge != False):
+    elif((args.select_library != None) or (args.allshows != False) or (args.allmovies != False)) and (args.purge != False):
         print('\nERROR - The \"--purge\" argument cannot be used in conjuction with the following arguments:')
         print(f'        --select-library\n        --allshows\n        --allmovies\n')
         time.sleep(3)

--- a/plex_playlist_generator.py
+++ b/plex_playlist_generator.py
@@ -75,8 +75,10 @@ BLACKLIST = ['Downton Abbey',
 #                    as a paramater an error would occur.                                                                                        #
 #                  - [Bug Fixes] Fixed a bug where some movies would be prevented from being added to a playlist due to an already added item    #
 #                    being attemptedly added multiple times; however, since it is already in the playlist it was not added again                 #
-#                    but still caused the playlist count to be lower than expected at times due to this.                                         #                                               #
-#                  - [Improvements] Added a check to make sure a user entered either a --adminuser argument or a --homeusers argument.           #                                                                    #
+#                    but still caused the playlist count to be lower than expected at times due to this.                                         #
+#                  - [Enhancements] Added a check to make sure a user entered either a --adminuser argument or a --homeusers argument.           #
+#                  - [Enhancements] Added the ability to purge a playlist without providing the --select-library, --allshows,                    #
+#                    or --allmovies arguments.                                                                                                   #
 ##################################################################################################################################################
 
 
@@ -1369,11 +1371,11 @@ def main():
         print(f'\nERROR - The script requires the use of at least one User.\n\nAvailable options:\n [1] - adminuser (--adminuser) \n [2] - homeusers (--homeusers "Username1,Username2,...")\n')
         exit(1)
 
-    #If the user does not pass in either of the following arguments: --selectlibrary, --allshows, or --allmovies
-    if(args.select_library == None) and (args.allshows == False) and (args.allmovies == False):
+    #If the user does not pass in either of the following arguments: --selectlibrary, --allshows, or --allmovies, or --purge
+    if(args.select_library == None) and (args.allshows == False) and (args.allmovies == False) and (args.purge == False):
         print('\nERROR - One of the required arguments must be selected.')
         print(f'        Rerun your command with one of the following required Arguments:')
-        print(f'        --selectlibrary\n        --allshows\n        --allmovies\n')
+        print(f'        --selectlibrary\n        --allshows\n        --allmovies\n        --purge\n')
         time.sleep(3)
         exit(1)
 

--- a/plex_playlist_generator.py
+++ b/plex_playlist_generator.py
@@ -76,6 +76,7 @@ BLACKLIST = ['Downton Abbey',
 #                  - [Bug Fixes] Fixed a bug where some movies would be prevented from being added to a playlist due to an already added item    #
 #                    being attemptedly added multiple times; however, since it is already in the playlist it was not added again                 #
 #                    but still caused the playlist count to be lower than expected at times due to this.                                         #                                               #
+#                  - [Improvements] Added a check to make sure a user entered either a --adminuser argument or a --homeusers argument.           #                                                                    #
 ##################################################################################################################################################
 
 
@@ -1362,6 +1363,11 @@ def main():
     elif(args.select_library != None) and (args.allmovies == True):
         print(f'\nERROR - The \"selectLibrary\" argument cannot be used in conjunction with the \"allmovies\" argument.\n')
         exit(1)
+    
+    #If the user does not provide a user to apply the playlist creation/deletion to, print an Error, and exit.
+    if(args.adminuser != True) and (args.homeusers == None):
+        print(f'\nERROR - The script requires the use of at least one User.\n\nAvailable options:\n [1] - adminuser (--adminuser) \n [2] - homeusers (--homeusers "Username1,Username2,...")\n')
+        exit(1)
 
     #If the user does not pass in either of the following arguments: --selectlibrary, --allshows, or --allmovies
     if(args.select_library == None) and (args.allshows == False) and (args.allmovies == False):
@@ -1486,7 +1492,7 @@ def main():
                 generate_all_users_playlist_via_server_method(args.baseurl, args.token)
             
         else:
-            #print That the connection method is required to proceed.
+            #Print that the connection method is required to proceed.
             print(f'\nERROR - The script requires the use of ONE connection method to proceed.\n\nAvailable options:\n [1] - account (--account) \n [2] - server (--server)\n')
             exit(1)
             

--- a/plex_playlist_generator.py
+++ b/plex_playlist_generator.py
@@ -1128,7 +1128,7 @@ def generate_all_users_playlist_via_server_method(base_url, authToken, homeUsers
                 continue
                 
         #If none of the users entered by the user are valid
-        if (numberValidHomeUsersEntered <= 0):
+        if((args.homeusers != None) and (numberValidHomeUsersEntered <= 0)):
             print(f'\nError - No Valid Home Users Submitted.\n')
             exit(1)
 
@@ -1313,7 +1313,7 @@ def generate_all_users_playlist_via_account_method(plexConnection, accountInfo, 
                 continue
 
         #If none of the users entered by the user are valid
-        if (numberValidHomeUsersEntered <= 0):
+        if((args.homeusers != None) and (numberValidHomeUsersEntered <= 0)):
             print(f'\nError - No Valid Home Users Submitted.\n')
             exit(1)
             

--- a/plex_playlist_generator.py
+++ b/plex_playlist_generator.py
@@ -79,6 +79,10 @@ BLACKLIST = ['Downton Abbey',
 #                  - [Enhancements] Added a check to make sure a user entered either a --adminuser argument or a --homeusers argument.           #
 #                  - [Enhancements] Added the ability to purge a playlist without providing the --select-library, --allshows,                    #
 #                    or --allmovies arguments.                                                                                                   #
+#                                                                                                                                                #
+#       12/07/2024 - [Enhancement] Added the ability to Filter and grab Shows/Movies from a specific Collection for the given libraries.         #
+#                    The playlist will only contain the provided Collections (I.E. --collections "Christmas Themed") from each library given.    #
+#                  - [Enhancement] Added the option to skip the printout of the generated playlist using --skip-printout.                        #
 ##################################################################################################################################################
 
 
@@ -89,6 +93,8 @@ def get_args():
     parser.add_argument('--name', help='Playlist Name', default='[Auto-Generated]')
     parser.add_argument('--number', '-n', help='Number of episodes or Movies to add to play list', type=int, default=10)
     parser.add_argument('--debug', '-d', help='Debug Logging', action="store_true")
+    #Use --skip-printout to not print out the output of the generated playlist (this will save time running thge scipt since it will not have to take time printing the contents to the screen). 
+    parser.add_argument('--skip-printout', action='store_true', help='Skip printing the output to the console (will decrease runtime).', default=False)
     group_server = parser.add_argument_group('Server Connection Method')
     group_server.add_argument('--server', action='store_true', help='Server connection Method')
     group_server.add_argument('--baseurl', '-b', help='Base URL of Server (I.E \"http://10.1.1.8:32400\" or \"https://your.domain.com:32400\")', type=str, default="http://localhost:32400")
@@ -110,6 +116,11 @@ def get_args():
     #The Exclude data will be used in conjuction with either --allshows or --allmovies
     group_libraries.add_argument('--exclude-library', '-e', help='Comma seperated list (if selecting multiple users) of sections to exclude (I.E. "Test Videos,Workout,Home Videos" ) there should be no space between the comma and the first character of the next value', type=str, default="")
     group_libraries.add_argument('--purge', help='Remove a playlist from plex for the provided user(s)', action='store_true', default=False)  
+    #The Tags group will be used to obtain Tags (I.E. Collections), and will be used to further filter from the provided selections, and only grab selections whose Collections Tag includes 
+    group_tags = parser.add_argument_group('Collections Tag Filter')    
+    #Filters out anything whose not a part of the provided Plex Collection for each library that the user selects.
+    # Added the option '--collection' which takes an argument of a Collection Name, in order to only grab items from the specified collection by name in order to add them to the playlist generation. The collection name provided will be used to query through each associated library, filtering and grabbing items who are part of a collection with the same name to add them to the playlist.
+    group_tags.add_argument('--collection', '-c', help='Retrieve\'s items that are part of a Collection matching the name provided to \'--collection\', and will be applied to each library that the user selected.')
     group_users = parser.add_argument_group('User Profile Selection')    
     #Used for Entering the Admin user(s) 
     group_users.add_argument('--adminuser', '-a', help='Generate playlist for the Plex Admin user profile name that was used to login.', action='store_true', default=False)
@@ -137,52 +148,132 @@ def get_random_episodes_or_movies(plex, all_provided_sections, requested_playlis
     #Used to determine whether to append to a empty library section all content, or add to concatinate an existing set of data
     count = 0
     
+    #The Location of where the season should begin beyond (greater than)
+    startSeasonFrom = 0
+    
+    #Library Type (Used to request episodes in search from the API)
+    getEpisode = 'episode'
+    
+    #Used to find unwatched episodes
+    unwatched = 0
+    
 
     for provided_section in all_provided_sections:
         if count == 0:
             if(args.include_watched == True):
-                all_shows_or_movies_from_provided_sections = plex.library.section(provided_section).all()
-                logger.debug(f'\nall_shows_or_movies_from_provided_sections[{count}] = {all_shows_or_movies_from_provided_sections}')
+                if getMovieSectionSearcher in str(plex.library.section(provided_section)):
+                    #If args.collection is provided then only find matching collecton items within the associated library (I.E. Collections found in [Edit > Tags > Collections] within the Web interface)
+                    if(args.collection != None):
+                        all_shows_or_movies_from_provided_sections = plex.library.section(provided_section).search(collection=args.collection)
+                        logger.debug(f'\nall_shows_or_movies_from_provided_sections[{count}] -- including only items containing collection \"{args.collection}\" = {all_shows_or_movies_from_provided_sections}')
+                    else:
+                        all_shows_or_movies_from_provided_sections = plex.library.section(provided_section).all()
+                        #all_shows_or_movies_from_provided_sections = plex.library.section(provided_section).search(libtype='episode')
+                        logger.debug(f'\nall_shows_or_movies_from_provided_sections[{count}] = {all_shows_or_movies_from_provided_sections}')
+                elif getShowSectionSearcher in str(plex.library.section(provided_section)):
+                    #If args.collection is provided then only find matching collecton items within the associated library (I.E. Collections found in [Edit > Tags > Collections] within the Web interface)
+                    if(args.collection != None):
+                        all_shows_or_movies_from_provided_sections = plex.library.section(provided_section).search(collection=args.collection)
+                        logger.debug(f'\nall_shows_or_movies_from_provided_sections[{count}] -- including only items containing collection \"{args.collection}\" = {all_shows_or_movies_from_provided_sections}')
+                    else:
+                        all_shows_or_movies_from_provided_sections = plex.library.section(provided_section).all()
+                        logger.debug(f'\nall_shows_or_movies_from_provided_sections[{count}] = {all_shows_or_movies_from_provided_sections}')
             else:
-                all_shows_or_movies_from_provided_sections = plex.library.section(provided_section).all(unwatched=True)
-                logger.debug(f'\nall_shows_or_movies_from_provided_sections[{count}] = {all_shows_or_movies_from_provided_sections}')
+                #If args.collection is provided then only find matching collecton items within the associated library (I.E. Collections found in [Edit > Tags > Collections] within the Web interface)
+                if(args.collection != None):
+                    all_shows_or_movies_from_provided_sections = plex.library.section(provided_section).search(collection=args.collection, unwatched=True)
+                    logger.debug(f'\nall_shows_or_movies_from_provided_sections[{count}] -- including only items containing collection \"{args.collection}\" = {all_shows_or_movies_from_provided_sections}')
+                else:
+                    all_shows_or_movies_from_provided_sections = plex.library.section(provided_section).all(unwatched=True)
+                    logger.debug(f'\nall_shows_or_movies_from_provided_sections[{count}] = {all_shows_or_movies_from_provided_sections}')
                 
             if getShowSectionSearcher in str(plex.library.section(provided_section)):
-                all_shows_from_provided_sections = plex.library.section(provided_section).all()
+                #If args.collection is provided then only find matching collecton items within the associated library (I.E. Collections found in [Edit > Tags > Collections] within the Web interface)
+                if(args.collection != None):
+                    all_shows_from_provided_sections = plex.library.section(provided_section).search(collection=args.collection)
+                    logger.debug(f'\nall_shows_from_provided_sections[{count}] -- including only items containing collection \"{args.collection}\" = {all_shows_from_provided_sections}')
+                else:
+                    all_shows_from_provided_sections = plex.library.section(provided_section).all()
+                    logger.debug(f'\nall_shows_from_provided_sections[{count}] = {all_shows_from_provided_sections}')
                 
             elif getMovieSectionSearcher in str(plex.library.section(provided_section)):
                 if(args.include_watched == True):
-                    logger.debug(f'\nIncluding Watched Movies...\n')
-                    all_movies_from_provided_sections = plex.library.section(provided_section).all()
-                    
+                    #If args.collection is provided then only find matching collecton items within the associated library (I.E. Collections found in [Edit > Tags > Collections] within the Web interface)
+                    if(args.collection != None):
+                        logger.debug(f'\nIncluding Watched Movies...\n')
+                        all_movies_from_provided_sections = plex.library.section(provided_section).search(collection=args.collection)
+                        logger.debug(f'\nall_movies_from_provided_sections[{count}] -- including only items containing collection \"{args.collection}\" = {all_movies_from_provided_sections}')
+                    else:
+                        logger.debug(f'\nIncluding Watched Movies...\n')
+                        all_movies_from_provided_sections = plex.library.section(provided_section).all()
+                        logger.debug(f'\nall_movies_from_provided_sections[{count}] = {all_movies_from_provided_sections}')
                 else:
-                    logger.debug(f'\nExcluding Watched Movies...\n')
-                    all_movies_from_provided_sections = plex.library.section(provided_section).all(unwatched=True)
+                    #If args.collection is provided then only find matching collecton items within the associated library (I.E. Collections found in [Edit > Tags > Collections] within the Web interface)
+                    if(args.collection != None):
+                        logger.debug(f'\nExcluding Watched Movies...\n')
+                        all_movies_from_provided_sections = plex.library.section(provided_section).search(collection=args.collection, unwatched=True)
+                        logger.debug(f'\nall_movies_from_provided_sections[{count}] -- including only items containing collection \"{args.collection}\" = {all_movies_from_provided_sections}')
+                    else:
+                        logger.debug(f'\nExcluding Watched Movies...\n')
+                        all_movies_from_provided_sections = plex.library.section(provided_section).all(unwatched=True)
+                        logger.debug(f'\nall_movies_from_provided_sections[{count}] = {all_movies_from_provided_sections}')
                 
             count += 1
         else:
             if(args.include_watched == True):
-                all_shows_or_movies_from_provided_sections = all_shows_or_movies_from_provided_sections + plex.library.section(provided_section).all()
-                logger.debug(f'\nall_shows_or_movies_from_provided_sections[{count}] = {all_shows_or_movies_from_provided_sections}')
+                #If args.collection is provided then only find matching collecton items within the associated library (I.E. Collections found in [Edit > Tags > Collections] within the Web interface)
+                if(args.collection != None):
+                    all_shows_or_movies_from_provided_sections = all_shows_or_movies_from_provided_sections + plex.library.section(provided_section).search(collection=args.collection)
+                    logger.debug(f'\nall_shows_or_movies_from_provided_sections[{count}] -- including only items containing collection \"{args.collection}\" = {all_shows_or_movies_from_provided_sections}')
+                else:
+                    all_shows_or_movies_from_provided_sections = all_shows_or_movies_from_provided_sections + plex.library.section(provided_section).all()
+                    logger.debug(f'\nall_shows_or_movies_from_provided_sections[{count}] = {all_shows_or_movies_from_provided_sections}')
             else:
-                all_shows_or_movies_from_provided_sections = all_shows_or_movies_from_provided_sections + plex.library.section(provided_section).all(unwatched=True)
-                logger.debug(f'\nall_shows_or_movies_from_provided_sections[{count}] = {all_shows_or_movies_from_provided_sections}')
+                #If args.collection is provided then only find matching collecton items within the associated library (I.E. Collections found in [Edit > Tags > Collections] within the Web interface)
+                if(args.collection != None):
+                    logger.debug(f'\nExcluding Watched Shows...\n')
+                    all_shows_or_movies_from_provided_sections = all_shows_or_movies_from_provided_sections + plex.library.section(provided_section).search(collection=args.collection, unwatched=True)
+                    logger.debug(f'\nall_shows_or_movies_from_provided_sections[{count}] -- including only items containing collection \"{args.collection}\" = {all_shows_or_movies_from_provided_sections}')
+                else:
+                    logger.debug(f'\nExcluding Watched Shows...\n')
+                    all_shows_or_movies_from_provided_sections = all_shows_or_movies_from_provided_sections + plex.library.section(provided_section).all(unwatched=True)
+                    logger.debug(f'\nall_shows_or_movies_from_provided_sections[{count}] = {all_shows_or_movies_from_provided_sections}')
 
    
             if getShowSectionSearcher in str(plex.library.section(provided_section)):
-                all_shows_from_provided_sections = all_shows_from_provided_sections + plex.library.section(provided_section).all()
-                logger.debug(f'\nall_shows_from_provided_sections = {all_shows_from_provided_sections}')
+                #If args.collection is provided then only find matching collecton items within the associated library (I.E. Collections found in [Edit > Tags > Collections] within the Web interface)
+                if(args.collection != None):
+                    all_shows_from_provided_sections = all_shows_from_provided_sections + plex.library.section(provided_section).search(collection=args.collection)
+                    logger.debug(f'\nall_shows_from_provided_sections -- including only items containing collection \"{args.collection}\" = {all_shows_from_provided_sections}')
+                else:
+                    all_shows_from_provided_sections = all_shows_from_provided_sections + plex.library.section(provided_section).all()
+                    logger.debug(f'\nall_shows_from_provided_sections -- including only items containing collection \"{args.collection}\" = {all_shows_from_provided_sections}')
                 
             elif getMovieSectionSearcher in str(plex.library.section(provided_section)):
                 if(args.include_watched == True):
-                    #If the user did select to include watched movies with --include-watched
-                    logger.debug(f'\nIncluding Watched Movies...\n')
-                    all_movies_from_provided_sections = all_movies_from_provided_sections + plex.library.section(provided_section).all()
-                    
+                    #If args.collection is provided then only find matching collecton items within the associated library (I.E. Collections found in [Edit > Tags > Collections] within the Web interface)
+                    if(args.collection != None):
+                        #If the user did select to include watched movies with --include-watched
+                        logger.debug(f'\nIncluding Watched Movies...\n')
+                        all_movies_from_provided_sections = all_movies_from_provided_sections + plex.library.section(provided_section).search(collection=args.collection)
+                        logger.debug(f'\nall_movies_from_provided_sections -- including only items containing collection \"{args.collection}\" = {all_movies_from_provided_sections}')
+                    else:
+                        #If the user did select to include watched movies with --include-watched
+                        logger.debug(f'\nIncluding Watched Movies...\n')
+                        all_movies_from_provided_sections = all_movies_from_provided_sections + plex.library.section(provided_section).all()
+                   
                 else:
-                    #If the user did not select to include watched movies with --include-watched
-                    logger.debug(f'\nExcluding Watched Movies...\n')
-                    all_movies_from_provided_sections = all_movies_from_provided_sections + plex.library.section(provided_section).all(unwatched=True)
+                    #If args.collection is provided then only find matching collecton items within the associated library (I.E. Collections found in [Edit > Tags > Collections] within the Web interface)
+                    if(args.collection != None):
+                        #If the user did not select to include watched movies with --include-watched
+                        logger.debug(f'\nExcluding Watched Movies...\n')
+                        all_movies_from_provided_sections = all_movies_from_provided_sections + plex.library.section(provided_section).search(collection=args.collection, unwatched=True)
+                        logger.debug(f'\nall_movies_from_provided_sections -- including only items containing collection \"{args.collection}\" = {all_movies_from_provided_sections}')
+                    else:
+                        #If the user did not select to include watched movies with --include-watched
+                        logger.debug(f'\nExcluding Watched Movies...\n')
+                        all_movies_from_provided_sections = all_movies_from_provided_sections + plex.library.section(provided_section).all(unwatched=True)
+                        logger.debug(f'\nall_movies_from_provided_sections = {all_movies_from_provided_sections}')
 
                 logger.debug(f'\nall_movies_from_provided_sections = {all_movies_from_provided_sections}')
                 
@@ -207,9 +298,9 @@ def get_random_episodes_or_movies(plex, all_provided_sections, requested_playlis
                 continue
             if args.include_watched is True:
                 #Grab Watched Episodes but ignore Season 0 (Specials)
-                show_episodes[show.title] = show.episodes(parentIndex__gt=0)
+                show_episodes[show.title] = show.episodes(parentIndex__gt=startSeasonFrom)
             else:
-                show_episodes[show.title] = show.unwatched()
+                show_episodes[show.title] = show.episodes(viewCount=unwatched, parentIndex__gt=startSeasonFrom)
               
 
             #Get the Season number of the Show
@@ -504,53 +595,55 @@ def build_playlist(plex, userName, plex_refined_library_sections, selectionsToEx
             print(f'Error - Unable to generate the Playlist \"{args.name}\"')
             exit(1)
 
-        #Print the Episode added to the playlist
-        for episode_movie in episode_or_movie:
-            #If the media type is show then print the output for the show details
-            if episode_movie.TYPE in getShow:
-                print('\n-----------------------------------')
-                print('[RANDOMIZED EPISODES]')
-                print(f'Username: {userName}')
-                print(f'Library Selection: {episode_movie.librarySectionTitle}')  
+        #If the User used the --skip-printout argument then skip printing the playlist out to the console.
+        if(args.skip_printout != True):
+            #Print the Episode added to the playlist
+            for episode_movie in episode_or_movie:
+                #If the media type is show then print the output for the show details
+                if episode_movie.TYPE in getShow:
+                    print('\n-----------------------------------')
+                    print('[RANDOMIZED EPISODES]')
+                    print(f'Username: {userName}')
+                    print(f'Library Selection: {episode_movie.librarySectionTitle}')  
 
-                #If no library sections are to be excluded print None for the excluded Library sections
-                if (not selectionsToExclude_List) or (args.exclude_library == ''):
-                    print(f'\nExcluded Library Sections: None')
+                    #If no library sections are to be excluded print None for the excluded Library sections
+                    if (not selectionsToExclude_List) or (args.exclude_library == ''):
+                        print(f'\nExcluded Library Sections: None')
 
-                else:
-                    #Remove Empty strings from the list
-                    selectionsToExclude_List = list(filter(None, selectionsToExclude_List))
-                    print(f'\nExcluded Library Sections: {selectionsToExclude_List}')
-        
-                season_episode = episode_movie.seasonEpisode
-                logger.debug(f'\n\nEpisode [label] = {(episode_movie.TYPE)}\n\n')
-                print(f'\nAdded to Playlist [{args.name}]: \"{episode_movie.grandparentTitle} - {episode_movie.parentTitle} - '
-                      f'Ep.0{episode_movie.index} - {episode_movie.title}\"')
-                  
-                libraryCount += 1
-                print(f'Number of Items in Playlist: {libraryCount}\n')
-                
-            #If the media type is movie then print the output for the movie details
-            elif episode_movie.TYPE in getMovie:
-                print('\n-----------------------------------')
-                print('[RANDOMIZED MOVIES]')
-                print(f'Username: {userName}')
-                print(f'Library Selection: {episode_movie.librarySectionTitle}')
-                
-                #If no library sections are to be excluded print None for the excluded Library sections
-                if (not selectionsToExclude_List) or (args.exclude_library == ''):
-                    print(f'\nExcluded Library Sections: None')
+                    else:
+                        #Remove Empty strings from the list
+                        selectionsToExclude_List = list(filter(None, selectionsToExclude_List))
+                        print(f'\nExcluded Library Sections: {selectionsToExclude_List}')
+            
+                    season_episode = episode_movie.seasonEpisode
+                    logger.debug(f'\n\nEpisode [label] = {(episode_movie.TYPE)}\n\n')
+                    print(f'\nAdded to Playlist [{args.name}]: \"{episode_movie.grandparentTitle} - {episode_movie.parentTitle} - '
+                          f'Ep.0{episode_movie.index} - {episode_movie.title}\"')
+                      
+                    libraryCount += 1
+                    print(f'Number of Items in Playlist: {libraryCount}\n')
+                    
+                #If the media type is movie then print the output for the movie details
+                elif episode_movie.TYPE in getMovie:
+                    print('\n-----------------------------------')
+                    print('[RANDOMIZED MOVIES]')
+                    print(f'Username: {userName}')
+                    print(f'Library Selection: {episode_movie.librarySectionTitle}')
+                    
+                    #If no library sections are to be excluded print None for the excluded Library sections
+                    if (not selectionsToExclude_List) or (args.exclude_library == ''):
+                        print(f'\nExcluded Library Sections: None')
 
-                else:
-                    #Remove Empty strings from the list
-                    selectionsToExclude_List = list(filter(None, selectionsToExclude_List))
-                    print(f'\nExcluded Library Sections: {selectionsToExclude_List}')
+                    else:
+                        #Remove Empty strings from the list
+                        selectionsToExclude_List = list(filter(None, selectionsToExclude_List))
+                        print(f'\nExcluded Library Sections: {selectionsToExclude_List}')
 
-                logger.debug(f'\n\nMovie [label] = {(episode_movie.TYPE)}\n\n')
-                print(f'\nAdded to Playlist [{args.name}]: \"{episode_movie.title}\"')
-                
-                libraryCount += 1
-                print(f'Number of Items in Playlist: {libraryCount}\n')
+                    logger.debug(f'\n\nMovie [label] = {(episode_movie.TYPE)}\n\n')
+                    print(f'\nAdded to Playlist [{args.name}]: \"{episode_movie.title}\"')
+                    
+                    libraryCount += 1
+                    print(f'Number of Items in Playlist: {libraryCount}\n')
 
 
     #For TV Shows Only
@@ -577,31 +670,33 @@ def build_playlist(plex, userName, plex_refined_library_sections, selectionsToEx
             exit(1)
         
 
-        #Print the Episode added to the playlist
-        for episode_movie in episode_or_movie:
-            #If the media type is show then print the output for the show details
-            if episode_movie.TYPE in getShow:
-                print('\n-----------------------------------')
-                print('[RANDOMIZED EPISODES]')
-                print(f'Username: {userName}')
-                print(f'Library Selection: {episode_movie.librarySectionTitle}')  
+        #If the User used the --skip-printout argument then skip printing the playlist out to the console.
+        if(args.skip_printout != True):
+            #Print the Episode added to the playlist
+            for episode_movie in episode_or_movie:
+                #If the media type is show then print the output for the show details
+                if episode_movie.TYPE in getShow:
+                    print('\n-----------------------------------')
+                    print('[RANDOMIZED EPISODES]')
+                    print(f'Username: {userName}')
+                    print(f'Library Selection: {episode_movie.librarySectionTitle}')  
 
-                #If no library sections are to be excluded print None for the excluded Library sections
-                if (not selectionsToExclude_List) or (args.exclude_library == ''):
-                    print(f'\nExcluded Library Sections: None')
+                    #If no library sections are to be excluded print None for the excluded Library sections
+                    if (not selectionsToExclude_List) or (args.exclude_library == ''):
+                        print(f'\nExcluded Library Sections: None')
 
-                else:
-                    #Remove Empty strings from the list
-                    selectionsToExclude_List = list(filter(None, selectionsToExclude_List))
-                    print(f'\nExcluded Library Sections: {selectionsToExclude_List}')
-        
-                logger.debug(f'\n\nEpisode [label] = {(episode_movie.TYPE)}\n\n')
-                season_episode = episode_movie.seasonEpisode      
-                print(f'\nAdded to Playlist [{args.name}]: \"{episode_movie.grandparentTitle} - {episode_movie.parentTitle} - '
-                      f'Ep.0{episode_movie.index} - {episode_movie.title}\"')
-                  
-                libraryCount += 1
-                print(f'Number of Items in Playlist: {libraryCount}\n')
+                    else:
+                        #Remove Empty strings from the list
+                        selectionsToExclude_List = list(filter(None, selectionsToExclude_List))
+                        print(f'\nExcluded Library Sections: {selectionsToExclude_List}')
+            
+                    logger.debug(f'\n\nEpisode [label] = {(episode_movie.TYPE)}\n\n')
+                    season_episode = episode_movie.seasonEpisode      
+                    print(f'\nAdded to Playlist [{args.name}]: \"{episode_movie.grandparentTitle} - {episode_movie.parentTitle} - '
+                          f'Ep.0{episode_movie.index} - {episode_movie.title}\"')
+                      
+                    libraryCount += 1
+                    print(f'Number of Items in Playlist: {libraryCount}\n')
 
            
     #For Movies Only      
@@ -628,29 +723,31 @@ def build_playlist(plex, userName, plex_refined_library_sections, selectionsToEx
             exit(1)
 
         
-        #Print the Episode added to the playlist
-        for episode_movie in episode_or_movie:
-            #If the media type is movie then print the output for the movie details
-            if episode_movie.TYPE in getMovie:
-                print('\n-----------------------------------')
-                print('[RANDOMIZED MOVIES]')
-                print(f'Username: {userName}')
-                print(f'Library Selection: {episode_movie.librarySectionTitle}')
-                
-                #If no library sections are to be excluded print None for the excluded Library sections
-                if (not selectionsToExclude_List) or (args.exclude_library == ''):
-                    print(f'\nExcluded Library Sections: None')
+        #If the User used the --skip-printout argument then skip printing the playlist out to the console.
+        if(args.skip_printout != True):
+            #Print the Episode added to the playlist
+            for episode_movie in episode_or_movie:
+                #If the media type is movie then print the output for the movie details
+                if episode_movie.TYPE in getMovie:
+                    print('\n-----------------------------------')
+                    print('[RANDOMIZED MOVIES]')
+                    print(f'Username: {userName}')
+                    print(f'Library Selection: {episode_movie.librarySectionTitle}')
+                    
+                    #If no library sections are to be excluded print None for the excluded Library sections
+                    if (not selectionsToExclude_List) or (args.exclude_library == ''):
+                        print(f'\nExcluded Library Sections: None')
 
-                else:
-                    #Remove Empty strings from the list
-                    selectionsToExclude_List = list(filter(None, selectionsToExclude_List))
-                    print(f'\nExcluded Library Sections: {selectionsToExclude_List}')
+                    else:
+                        #Remove Empty strings from the list
+                        selectionsToExclude_List = list(filter(None, selectionsToExclude_List))
+                        print(f'\nExcluded Library Sections: {selectionsToExclude_List}')
 
-                logger.debug(f'\n\nMovie [label] = {(episode_movie.TYPE)}\n\n')
-                print(f'\nAdded to Playlist [{args.name}]: \"{episode_movie.title}\"')
-                
-                libraryCount += 1
-                print(f'Number of Items in Playlist: {libraryCount}\n')
+                    logger.debug(f'\n\nMovie [label] = {(episode_movie.TYPE)}\n\n')
+                    print(f'\nAdded to Playlist [{args.name}]: \"{episode_movie.title}\"')
+                    
+                    libraryCount += 1
+                    print(f'Number of Items in Playlist: {libraryCount}\n')
 
 
 
@@ -798,7 +895,6 @@ def create_playlist(plex, account):
     loopCount = 0  
     
     for library in plex_all_library_sections:
-
         #Use a regex to match exactly the library sections, otherwise it will find any library containing the library variable 
         library_exact_matcher_regex = '^' + re.escape(library) + '$'
         library_regex = re.compile(library_exact_matcher_regex)
@@ -1366,6 +1462,14 @@ def main():
         print(f'\nERROR - The \"--select-library\" argument cannot be used in conjunction with the \"--allmovies\" argument.\n')
         exit(1)
     
+    #If the collections argument is used, then one of the following arguments must not be empty: args.allshows, args.allmovies, args.select_library
+    if(args.collection != None) and (args.select_library == None) and (args.allshows == False) and (args.allmovies == False):
+        #print(f'\ncollection = \"{args.collection}\"\nselect_library = \"{args.select_library}\"\nallshows = \"{args.allshows}\"\nallmovies = \"{args.allmovies}\"\n')
+        print('\nERROR - The \"--collection\" argument MUST be used in conjuction with at least one of the following arguments:')
+        print(f'        --select-library\n        --allshows\n        --allmovies\n')
+        time.sleep(3)
+        exit(1)
+    
     #If the user does not provide a user to apply the playlist creation/deletion to, print an Error, and exit.
     if(args.adminuser != True) and (args.homeusers == None):
         print(f'\nERROR - The script requires the use of at least one User.\n\nAvailable options:\n [1] - adminuser (--adminuser) \n [2] - homeusers (--homeusers "Username1,Username2,...")\n')
@@ -1377,6 +1481,8 @@ def main():
         print(f'        Rerun your command with one of the following required Arguments:')
         print(f'        --select-library\n        --allshows\n        --allmovies\n        --purge\n')
         time.sleep(3)
+        
+        
         exit(1)
     #If purge argument is used, then it should not be used at the same time as the following arguments: --select-library, --allshows, or --allmovies
     elif((args.select_library != None) or (args.allshows != False) or (args.allmovies != False)) and (args.purge != False):
@@ -1392,7 +1498,7 @@ def main():
     elif(args.name == False):
         print(f'The argument \"--name\" is required and cannot be ommitted.\nPlease provide the name argument and try again.\n')
         exit(1)
-       
+      
     if(args.number > 0):
         #Select home Users
         if(args.homeusers):


### PR DESCRIPTION
[Script - Changes]
1 - Added the ability to skip the printout of the playlist to the console with the '--skip-printout' option.
2 - Added an option '--collection' which takes an argument of a Collection Name, in order to only grab items from the specified collection by name in order to add them to the playlist generation. The collection name provided will be used to query through each associated library, filtering and grabbing items who are part of a collection with the same name to add them to the playlist.

[ReadMe - Changes]
1 - Added the help details and a usage example for '--skip-printout' argument.
2 - Added the help details and a usage example for '--collection' argument.